### PR TITLE
fix(cors): cors policy error

### DIFF
--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -5,4 +5,5 @@ export default axios.create({
   params: {
     key: "c7b18323a47d40c394ea5b019646b1f5",
   },
+  withCredentials: false,
 });


### PR DESCRIPTION
After deploying to vercel, the api request to rawg api endpoint is getting blocked due to CORS policy even after using correct api key.

Closes #2